### PR TITLE
BBC iPlayer : bbciplayer.json added

### DIFF
--- a/datafiles/streams/bbciplayer.json
+++ b/datafiles/streams/bbciplayer.json
@@ -1,0 +1,47 @@
+{
+  "name": "bbc.co.uk",
+  "attributes": {
+    "geolocked": true,
+    "region": "GB",
+    "language": "eng",
+    "hd": true
+  },
+  "streams": [
+    {"name": "bbcone",
+      "title": "BBC One",
+      "url": "http://www.bbc.co.uk/iplayer/live/bbcone"},
+    {"name": "bbctwo",
+      "title": "BBC Two",
+      "url": "http://www.bbc.co.uk/iplayer/live/bbctwo"},
+    {"name": "bbcthree",
+      "title": "BBC Three",
+      "url": "http://www.bbc.co.uk/iplayer/live/bbcthree"},
+    {"name": "bbcfour",
+      "title": "BBC Four",
+      "url": "http://www.bbc.co.uk/iplayer/live/bbcfour"},
+    {"name": "cbbc",
+      "title": "CBBC",
+      "url": "http://www.bbc.co.uk/iplayer/live/cbbc"},
+    {"name": "cbeebies",
+      "title": "Cbeebies",
+      "url": "http://www.bbc.co.uk/iplayer/live/cbeebies"},
+    {"name": "bbcnews",
+      "title": "BBC News",
+      "url": "http://www.bbc.co.uk/iplayer/live/bbcnews"},
+    {"name": "bbcparliament",
+      "title": "BBC Parliament",
+      "url": "http://www.bbc.co.uk/iplayer/live/bbcparliament"}, 
+    {"name": "bbcalba",
+      "title": "BBC Alba",
+      "url": "http://www.bbc.co.uk/iplayer/live/bbcalba",
+      "attributes": {
+        "language": "gla",
+        "hd": false}},
+    {"name": "s4c",
+      "title": "S4C",
+      "url": "http://www.bbc.co.uk/iplayer/live/s4c",
+      "attributes": {
+        "language": "cym",
+        "hd": false}}
+  ]
+}


### PR DESCRIPTION
BBC iPlayer channels : 
----------------------

1. BBC One
2. BBC Two
3. BBC Three
4. BBC Four
5. CBBC
6. Cbeebies
7. BBC News
8. BBC Parliament
9. BBC Alba
10. S4C

Notice : BBC Three isn't anymore linear channel but VOD only.